### PR TITLE
Partial for rendering flash alert messages

### DIFF
--- a/app/views/layouts/_flash_alerts.html.erb
+++ b/app/views/layouts/_flash_alerts.html.erb
@@ -1,0 +1,20 @@
+<div>
+  <% if flash[:notice].present? %>
+    <div class="alert alert-success">
+      <button type="button" class="close" data-dismiss="alert">&times;</button>
+      <%= flash[:notice] %>
+    </div>
+
+  <% elsif flash[:error].present? %>
+    <div class="alert alert-danger">
+      <button type="button" class="close" data-dismiss="alert">&times;</button>
+      <%= flash[:error] %>
+    </div>
+
+  <% elsif flash[:alert].present? %>
+    <div class="alert alert-warning">
+      <button type="button" class="close" data-dismiss="alert">&times;</button>
+      <%= flash[:alert] %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,8 +39,10 @@
       </div>
     </nav>
 
-  	<div class="container">
-    	<%= yield %>
+    <%= render "layouts/flash_alerts" %>
+
+    <div class="container">
+      <%= yield %>
     </div>
 
   </body>


### PR DESCRIPTION
#### What does this PR do?
 
Here is an alternative approach for rendering bootstrap flash alerts.  I'm not recommending that you merge this.  We definitely want to get all the "indent correcting" work you did into master.  More so, for you to compare the two pull requests to learn from the different implementations.

You can play with moving the `<%= render "layouts/flash_alerts" %>` call up above the `<nav>` tags.  You can further DRY this implementation up, too, if you'd like.

#### Pivotal Story
https://www.pivotaltracker.com/story/show/146264575

#### Screenshots

![image](https://cloud.githubusercontent.com/assets/7482329/26659847/3b8080c2-4631-11e7-8c00-dcab9db463ed.png)

